### PR TITLE
jed/fix-header-h1

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -272,6 +272,10 @@ textarea {
                     vertical-align:middle;
                 }
 
+                header h1 {
+                    padding-left: 0.5em;
+                }
+
                 header p {
                     max-width:20em;
                     margin-left:auto;


### PR DESCRIPTION
The letter spacing on the header's h1 was throwing off its centre alignment off by some 30px or so at its maximum size. Adding some left padding nudges it back.
